### PR TITLE
Try not using home folder permission

### DIFF
--- a/com.github.keriew.augustus.json
+++ b/com.github.keriew.augustus.json
@@ -4,7 +4,6 @@
     "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
-        "--filesystem=home:ro",
         "--share=ipc",
         "--device=dri",
         "--socket=wayland",


### PR DESCRIPTION
The game uses zenity for the directory picker, which in turn uses portals. That should be enough to provide persistent access to the data files, making the permission useless.